### PR TITLE
Fix or ignore more linting errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,15 @@
     "quotes": [2, "double", {"allowTemplateLiterals": true}],
     "prettier/prettier": "error",
     "no-invalid-this": 0,
-    "babel/no-invalid-this": 1
+    "babel/no-invalid-this": 1,
+    "react/prop-types": 0,
+    "react/jsx-handler-names": 0,
+    "no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_"
+      }
+    ],
+    "react/no-multi-comp": 0
   }
 }

--- a/TODO.md
+++ b/TODO.md
@@ -1,77 +1,74 @@
-* Switch default change scale to Minor Change
-* Bug: Various play buttons aren't mutually exclusive anymore - John
-* Bug: Start tone after user interaction (currently broken in Safari and Chrome)
-* Lineage can skip at beginning with lots of beats; investigate unnecessary re-rendering or other ways avoid skips - John
-* Actions at the bottom (rate, mutate), play at the bottom? - John
-* Switch star rating to how much to change slider - Luke
-* Solo/Gain for each section (ian)
-* Bug: All tracks can be Soloed at same time for drums
-* Duplicate beat in lineage - John
-* Pick lineage playback up where it left off, allow selecting starting beat when it's not currently playing
-* Load lineage from local storage
-* Name lineage
-* Rename beats
-* Undo 1 (or more) beat deletes
-* Additional ocave
-* Fix duplicate samplers
-* Add custom sections
-* URL sharing
+- Switch default change scale to Minor Change
+- Bug: Various play buttons aren't mutually exclusive anymore - John
+- Bug: Start tone after user interaction (currently broken in Safari and Chrome)
+- Lineage can skip at beginning with lots of beats; investigate unnecessary re-rendering or other ways avoid skips - John
+- Actions at the bottom (rate, mutate), play at the bottom? - John
+- Solo/Gain for each section (ian)
+- Bug: All tracks can be Soloed at same time for drums
+- Pick lineage playback up where it left off, allow selecting starting beat when it's not currently playing
+- Load lineage from local storage
+- Name lineage
+- Rename beats
+- Undo 1 (or more) beat deletes
+- Additional ocave
+- Fix duplicate samplers
+- Add custom sections
+- URL sharing
 
 Aryn Feedback
-* "kills the vibe" - developer blue, developer red, developer yellow, system blue (select dropdowns)
-* minibeat backgrounds: contrast between light gray and green is low
-* Move section controls to line across top potentially
-* Dot pattern across top of background, fade down ~300-500px
-* around sections: get rid of white bevel, make shadow more diffuse, use higher corner radius
-* light gray for titles of secondary things, labels, gain/delete icons
-* re-layout section controls
-* dropdowns: dark (but lighter than the background) with white/light text
-* background dot texture thing
+
+- "kills the vibe" - developer blue, developer red, developer yellow, system blue (select dropdowns)
+- minibeat backgrounds: contrast between light gray and green is low
+- Move section controls to line across top potentially
+- Dot pattern across top of background, fade down ~300-500px
+- around sections: get rid of white bevel, make shadow more diffuse, use higher corner radius
+- light gray for titles of secondary things, labels, gain/delete icons
+- re-layout section controls
+- dropdowns: dark (but lighter than the background) with white/light text
+- background dot texture thing
 
 Design Needed:
-* Describe workflow somewhere in simple terms ("listen, edit, rate, mutate, listen to lineage" - or whatever)
 
-* Live performance mode
-* Style play button/play controls for lineage
-  
-* Potentially:
-  * show tooltip on Kill Last Beat to encourage using it when user rates a beat 5 or less
-  * or only show the Kill Last Beat button when they rate the current beat 5 or less
+- Describe workflow somewhere in simple terms ("listen, edit, rate, mutate, listen to lineage" - or whatever)
 
-* Add back arrangement - as existing UI, or new single-view UI
-* Utility - beat diff metric
-    * longer lines between beats in a lineage depending on how much change
-    * Learn what manual changes a user makes to improve their beats (or what changes they rate highly)
+- Live performance mode
+- Style play button/play controls for lineage
 
+- Potentially:
 
-High value and/or easy:
-    * Synth Gain not working
+  - show tooltip on Kill Last Beat to encourage using it when user rates a beat 5 or less
+  - or only show the Kill Last Beat button when they rate the current beat 5 or less
 
-* Redesign sample selection (to test sample without changing) - John
-    * Categorize samples
+- Add back arrangement - as existing UI, or new single-view UI
+- Utility - beat diff metric
+  - longer lines between beats in a lineage depending on how much change
+  - Learn what manual changes a user makes to improve their beats (or what changes they rate highly)
+
+High value and/or easy: \* Synth Gain not working
+
+- Redesign sample selection (to test sample without changing) - John
+  - Categorize samples
 
 High value but hard:
-    * Export beat or arrangement as sound file would be amazing or share
-    * Online collaboration, let friends score things before mating
-    * Undo would be great
-    * Ability to change note duration
-    * Drag to change tempo
+_ Export beat or arrangement as sound file would be amazing or share
+_ Online collaboration, let friends score things before mating
+_ Undo would be great
+_ Ability to change note duration \* Drag to change tempo
 
 medium/low value:
-    * Note drag selection/deselection bug across tracks
-    * Make gain independent between beats
-    * Ability to “favorite” or rename beats
-    * Add number of subdivisions (aka note size in our case) to beat info header
-    * "Accented notes" for velocity approximation for samples, eg just having 1 extra option instead of range of velocity
-        * Make it possible to add two of same sample for now?
-    * Display rating on minibeat
-    * Hook up Google Analytics
+_ Note drag selection/deselection bug across tracks
+_ Make gain independent between beats
+_ Ability to “favorite” or rename beats
+_ Add number of subdivisions (aka note size in our case) to beat info header
+_ "Accented notes" for velocity approximation for samples, eg just having 1 extra option instead of range of velocity
+_ Make it possible to add two of same sample for now?
+_ Display rating on minibeat
+_ Hook up Google Analytics
 
 low value:
-    * Improve console error messages
-    * Effects for synth
-    * Add warning when playing but there are no notes to play
-
+_ Improve console error messages
+_ Effects for synth \* Add warning when playing but there are no notes to play
 
 Maintenance:
-* react-beautiful-dnd update: https://github.com/atlassian/react-beautiful-dnd/releases/tag/v10.0.0
+
+- react-beautiful-dnd update: https://github.com/atlassian/react-beautiful-dnd/releases/tag/v10.0.0

--- a/app/colors.js
+++ b/app/colors.js
@@ -46,11 +46,11 @@ const newColors = {
     darker: "#472AEF",
     dark: "#7331FD",
     base: "#535FFF",
-    light:"#9D72FE",
+    light: "#9D72FE",
   },
   yellow: {
     deep: "#FFB301",
-  }
+  },
 }
 
 export {colors, newColors}

--- a/app/components/app.js
+++ b/app/components/app.js
@@ -31,14 +31,12 @@ class App extends Component {
   handleKeyPress = (e) => {
     if (e.code === "Space") {
       playingStore.togglePlaying()
-      e.preventDefault()
     } else if (e.code === "ArrowRight") {
       familyStore.nextBeatInLineage()
-      e.preventDefault()
     } else if (e.code === "ArrowLeft") {
       familyStore.prevBeatInLineage()
-      e.preventDefault()
     }
+    e.preventDefault()
   }
 
   render() {

--- a/app/components/beatDetail.js
+++ b/app/components/beatDetail.js
@@ -232,16 +232,13 @@ class BeatDetail extends Component {
           ) : (
             <Button
               width={150}
-            color={[colors.blue.base]}
+              color={[colors.blue.base]}
               onClick={this.handleNewRandomBeat}
             >
               New Random Beat
             </Button>
           )}
-          <Button
-            width={150}
-            onClick={this.handleMutateAllSections}
-          >
+          <Button width={150} onClick={this.handleMutateAllSections}>
             Mutate Both Sections
           </Button>
         </div>

--- a/app/components/lineage.js
+++ b/app/components/lineage.js
@@ -38,7 +38,7 @@ const lineageProcessor = () => {
 
     const beat = familyStore.beats[beatId]
     //If beat was deleted from lineage mid execution
-    if(!beat){
+    if (!beat) {
       return
     }
     const samplerTracks = beat.sections.drums.tracks
@@ -127,7 +127,7 @@ class Lineage extends Component {
             this.handleClickPlayBeat(beat.id, i)
           }}
           handleClickBeat={() => {
-            this.handleClickBeat(beat.id, i )
+            this.handleClickBeat(beat.id, i)
           }}
         />
       )

--- a/app/components/miniBeat.js
+++ b/app/components/miniBeat.js
@@ -19,17 +19,14 @@ const noteBackgroundColor = (active, on, altColor) => {
     } else {
       return chroma("darkgray").brighten(0.6)
     }
+  } else if (on) {
+    return lightGreen
+  } else if (altColor) {
+    return "gray"
   } else {
-    if (on) {
-      return lightGreen
-    } else if (altColor) {
-      return "gray"
-    } else {
-      return chroma("gray").brighten(0.6)
-    }
+    return chroma("gray").brighten(0.6)
   }
 }
-
 
 const StyledBeat = styled.div`
   display: table;
@@ -41,7 +38,7 @@ const StyledBeat = styled.div`
 class MiniBeat extends Component {
   beatStore = playingStore.newBeatStore()
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(_prevProps, _prevState) {
     if (!this.props.playing) {
       this.beatStore.clearLitNote()
     }
@@ -122,9 +119,9 @@ class MiniTrack extends Component {
   }
 }
 
-
 const StyledNote = styled.div`
-  background-color: ${(props) => noteBackgroundColor(props.active, props.on, props.altColor)};
+  background-color: ${(props) =>
+    noteBackgroundColor(props.active, props.on, props.altColor)};
   box-shadow: ${(props) => (props.on ? `0 0 4px 0px ${lighterGreen}` : "none")};
   border-radius: 0px;
   border: 1px solid black;

--- a/app/components/note.js
+++ b/app/components/note.js
@@ -2,7 +2,6 @@ import React, {Component} from "react"
 import {observer} from "mobx-react"
 import styled from "styled-components"
 import chroma from "chroma-js"
-import {newColors} from "../colors"
 
 const NoteWrapper = styled.div`
   border-right: ${(props) => (props.separator ? "1px solid white" : "0")};

--- a/app/components/playControls.js
+++ b/app/components/playControls.js
@@ -38,7 +38,10 @@ class PlayControls extends Component {
           <MdSkipPrevious size={size} onClick={familyStore.prevBeatInLineage} />
         </Tooltip>
         <Tooltip position="top" text="Play / Stop">
-          <PlayStopButton size={size + 30} onClick={playingStore.togglePlaying} />
+          <PlayStopButton
+            size={size + 30}
+            onClick={playingStore.togglePlaying}
+          />
         </Tooltip>
         <Tooltip position="top" text="Next Beat">
           <MdSkipNext size={size} onClick={familyStore.nextBeatInLineage} />

--- a/app/components/player.js
+++ b/app/components/player.js
@@ -39,7 +39,7 @@ class Player extends Component {
     this.loop.dispose()
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps, _prevState) {
     if (this.props.playing && !prevProps.playing) {
       this.loop.start()
     } else if (!this.props.playing && prevProps.playing) {

--- a/app/components/samplerTrack.js
+++ b/app/components/samplerTrack.js
@@ -1,7 +1,6 @@
 import React, {Component} from "react"
 import {observer} from "mobx-react"
 import styled from "styled-components"
-import {MdDeleteForever} from "react-icons/md"
 import store from "../stores/store"
 import familyStore from "../stores/familyStore"
 import Note from "./note"
@@ -101,7 +100,7 @@ class Track extends Component {
           key={`${i}.${note}`}
           value={note}
           activeNotes={this.props.activeNotes}
-          onClick={(e) => {
+          onClick={(_) => {
             this.setState({
               lastEntered: i,
               lastClickedNoteWasOn:

--- a/app/mutate.js
+++ b/app/mutate.js
@@ -12,7 +12,7 @@ const mutateScale = (newBeat) => {
   newBeat.scale = scaleName
 
   let numSynthTracks = 0
-  newBeat.sections.keyboard.tracks.forEach((track, j) => {
+  newBeat.sections.keyboard.tracks.forEach((track, _) => {
     track.sample = SCALES[scaleName][numSynthTracks]
     numSynthTracks += 1
   })
@@ -20,7 +20,7 @@ const mutateScale = (newBeat) => {
 
 const mutateSynthType = (newBeat) => {
   const randomSynth = synthTypes[Math.floor(Math.random() * synthTypes.length)]
-  newBeat.sections.keyboard.tracks.forEach((track, j) => {
+  newBeat.sections.keyboard.tracks.forEach((track, _) => {
     track.synthType = randomSynth
   })
 }

--- a/app/scheduleInstruments.js
+++ b/app/scheduleInstruments.js
@@ -7,6 +7,7 @@ Tone.Transport.bpm.value = playingStore.tempo
 
 reaction(
   () => playingStore.tempo,
+  // eslint-disable-next-line no-unused-vars
   (tempo) => (Tone.Transport.bpm.value = playingStore.tempo),
 )
 
@@ -36,6 +37,7 @@ const synths = [{}, ["sine", 5], ["square", 0], ["triangle", 12]].reduce(
   },
 )
 
+// eslint-disable-next-line max-params
 const scheduleInstruments = (time, index, samplerTracks, synthTracks) => {
   const notes = {}
   const gainRange = 55

--- a/app/stores/familyStore.js
+++ b/app/stores/familyStore.js
@@ -220,14 +220,14 @@ class FamilyStore {
   @action setScale = (scaleName) => {
     this.currentBeat.scale = scaleName
     let numSynthTracks = 0
-    this.currentBeat.sections.keyboard.tracks.forEach((track, j) => {
+    this.currentBeat.sections.keyboard.tracks.forEach((track, _) => {
       track.sample = SCALES[scaleName][numSynthTracks]
       numSynthTracks += 1
     })
   }
 
   @action setSynthType = (type) => {
-    this.currentBeat.sections.keyboard.tracks.forEach((track, j) => {
+    this.currentBeat.sections.keyboard.tracks.forEach((track, _) => {
       track.synthType = type
     })
   }

--- a/app/stores/playingStore.js
+++ b/app/stores/playingStore.js
@@ -102,8 +102,8 @@ class PlayingStore {
 
   @action setLineagePlayingBeatIndex = (index) => {
     this.lineagePlayingBeatIndex = index
-  }  
-  
+  }
+
   @action toggleMuteAll = (lastState) => {
     const newState = !lastState
     Object.keys(familyStore.currentBeat.sections).forEach((sectionName) => {
@@ -127,7 +127,7 @@ class PlayingStore {
   }
   @action unsoloAllSamplerTracks = () => {
     familyStore.currentBeat.sections.drums.tracks.forEach((track) => {
-        track.solo = false
+      track.solo = false
     })
     this.numSolo = 0
   }
@@ -143,7 +143,9 @@ class PlayingStore {
       ++this.numSolo
       track.mute = false
       this.muteUnsolod()
-      if(this.numSolo === familyStore.currentBeat.sections.drums.tracks.length){
+      if (
+        this.numSolo === familyStore.currentBeat.sections.drums.tracks.length
+      ) {
         this.unsoloAllSamplerTracks()
       }
     } else {
@@ -152,7 +154,6 @@ class PlayingStore {
       if (this.numSolo === 0) {
         this.toggleMuteAll(true)
       }
-      
     }
   }
 }

--- a/app/stores/store.js
+++ b/app/stores/store.js
@@ -19,8 +19,8 @@ class Store {
     this.samples.push(newSample)
   }
 
-  @action setAllSamples = (samples) => {
-    this.samples = samples
+  @action setAllSamples = (targetSamples) => {
+    this.samples = targetSamples
   }
 
   @action setGain = (sample, gain) => {

--- a/app/styledComponents/column.js
+++ b/app/styledComponents/column.js
@@ -5,7 +5,7 @@ const Column = styled.div`
   display: inline-block;
   text-align: ${(props) =>
     props.textLeft ? "left" : props.textRight ? "right" : "center"};
-  width: ${(props) => props.width ? props.width : "300"}px;
+  width: ${(props) => (props.width ? props.width : "300")}px;
   margin-right: 10px;
 `
 


### PR DESCRIPTION
`nom run lint` now has only 2 errors related to nested ternary expressions embedded in some css.