### PR TITLE
WIP: Continuously evolve beat

### DIFF
--- a/app/components/beatDetail.js
+++ b/app/components/beatDetail.js
@@ -69,9 +69,9 @@ const StyledSection = styled.div`
   position: relative;
 `
 const MutateSection = styled.div`
-  margin-bottom: 20px; 
+  margin-bottom: 20px;
   margin-top: 10px;
-  padding : 15px;
+  padding: 15px;
   border: 1px solid ${chroma(newColors.purple.base)};
   border-radius: 8px;
   display: inline-block;
@@ -110,6 +110,16 @@ class BeatDetail extends Component {
     let newBeat = mutateMelody(familyStore.currentBeat)
     newBeat = mutateSampler(newBeat)
     familyStore.newBeatAfterCurrentBeat(newBeat)
+  }
+
+  handleMutateFloatingMelody = () => {
+    const newBeat = mutateMelody(familyStore.currentBeat)
+    familyStore.setFloatingBeat(newBeat)
+  }
+
+  handleMutateFloatingSampler = () => {
+    const newBeat = mutateSampler(familyStore.currentBeat)
+    familyStore.setFloatingBeat(newBeat)
   }
 
   handleKillLastBeat = () => {
@@ -214,7 +224,7 @@ class BeatDetail extends Component {
     return (
       <StyledBeat>
         <Player
-          beat={familyStore.currentBeat}
+          beat={familyStore.floatingBeat}
           playing={playingStore.playing}
           length={BEAT_LENGTH}
           resolution={BEAT_RESOLUTION}
@@ -245,10 +255,7 @@ class BeatDetail extends Component {
               New Random Beat
             </Button>
           )}
-          <Button
-            width={150}
-            onClick={this.handleMutateAllSections}
-          >
+          <Button width={150} onClick={this.handleMutateAllSections}>
             Evolve Both Sections
           </Button>
         </div>
@@ -285,12 +292,13 @@ class BeatDetail extends Component {
               </span>
               {scaleSelect}
             </div>
-            <br/>
+            <br />
             <MutateSection>
               <ChangeSlider
                 score={familyStore.currentBeat.synthScore}
                 handleSetScore={(score) => {
                   familyStore.setSynthScore(score)
+                  this.handleMutateFloatingMelody()
                 }}
               />
               <Button
@@ -314,12 +322,13 @@ class BeatDetail extends Component {
             >
               M
             </MuteTrackButton>
-            <br/>
+            <br />
             <MutateSection>
               <ChangeSlider
                 score={familyStore.currentBeat.samplerScore}
                 handleSetScore={(score) => {
                   familyStore.setSamplerScore(score)
+                  this.handleMutateFloatingSampler()
                 }}
               />
               <Button

--- a/app/components/beatDetail.js
+++ b/app/components/beatDetail.js
@@ -124,6 +124,7 @@ class BeatDetail extends Component {
       return (
         <SamplerTrack
           key={`${this.props.beat.key}.${i}`}
+          beat={this.props.beat}
           trackNum={i}
           track={track}
           handleMuteTrack={playingStore.handleMuteTrack}
@@ -149,6 +150,7 @@ class BeatDetail extends Component {
       return (
         <SynthTrack
           key={`${note}.${i}`}
+          beat={this.props.beat}
           trackNum={i}
           track={track}
           handleMuteTrack={playingStore.handleMuteTrack}
@@ -160,11 +162,15 @@ class BeatDetail extends Component {
   }
 
   handleSelectScale = (evt) => {
-    familyStore.setScale(evt.target.value)
+    familyStore.setScale(this.props.beat, evt.target.value)
   }
 
   handleSelectSynthType = (evt) => {
-    familyStore.setSynthType(evt.target.value)
+    familyStore.setSynthType(this.props.beat, evt.target.value)
+  }
+
+  handleToggleMonosynth = (_evt) => {
+    familyStore.toggleMonosynth(this.props.beat)
   }
 
   render() {
@@ -184,7 +190,7 @@ class BeatDetail extends Component {
       <select
         style={{fontSize: "20px"}}
         onChange={this.handleSelectScale}
-        value={familyStore.currentBeat.scale}
+        value={this.props.beat.scale}
       >
         {scaleOptions}
       </select>
@@ -264,8 +270,8 @@ class BeatDetail extends Component {
               <input
                 style={{fontSize: "15px"}}
                 type="checkbox"
-                onChange={familyStore.toggleMonosynth}
-                checked={familyStore.currentBeat.sections.keyboard.monosynth}
+                onChange={this.handleToggleMonosynth}
+                checked={familyStore.floatingBeat.sections.keyboard.monosynth}
               />
             </div>
             <div style={{width: "250px", margin: "0 auto", textAlign: "left"}}>

--- a/app/components/beatDetail.js
+++ b/app/components/beatDetail.js
@@ -96,20 +96,8 @@ class BeatDetail extends Component {
     this.disablePlayReaction()
   }
 
-  handleMutateMelody = () => {
-    const newBeat = mutateMelody(familyStore.currentBeat)
-    familyStore.newBeatAfterCurrentBeat(newBeat)
-  }
-
-  handleMutateSampler = () => {
-    const newBeat = mutateSampler(familyStore.currentBeat)
-    familyStore.newBeatAfterCurrentBeat(newBeat)
-  }
-
-  handleMutateAllSections = () => {
-    let newBeat = mutateMelody(familyStore.currentBeat)
-    newBeat = mutateSampler(newBeat)
-    familyStore.newBeatAfterCurrentBeat(newBeat)
+  handleSaveBeat = () => {
+    familyStore.newBeatAfterCurrentBeat(familyStore.floatingBeat)
   }
 
   handleMutateFloatingMelody = () => {
@@ -255,8 +243,8 @@ class BeatDetail extends Component {
               New Random Beat
             </Button>
           )}
-          <Button width={150} onClick={this.handleMutateAllSections}>
-            Evolve Both Sections
+          <Button width={150} onClick={this.handleSaveBeat}>
+            Save Beat
           </Button>
         </div>
 
@@ -301,13 +289,6 @@ class BeatDetail extends Component {
                   this.handleMutateFloatingMelody()
                 }}
               />
-              <Button
-                style={{marginLeft: "10px"}}
-                width={150}
-                onClick={this.handleMutateMelody}
-              >
-                Evolve Keyboard
-              </Button>
             </MutateSection>
             {this.renderSynthTracks(synthTracks)}
           </StyledSection>
@@ -331,13 +312,6 @@ class BeatDetail extends Component {
                   this.handleMutateFloatingSampler()
                 }}
               />
-              <Button
-                style={{marginLeft: "10px"}}
-                width={150}
-                onClick={this.handleMutateSampler}
-              >
-                Evolve Drums
-              </Button>
             </MutateSection>
             {this.renderSamplerTracks(samplerTracks)}
           </StyledSection>

--- a/app/components/beatDisplay.js
+++ b/app/components/beatDisplay.js
@@ -14,7 +14,7 @@ class BeatDisplay extends Component {
       } else {
         return <BeatDetail key={b.key} beat={b} />
       }
-    })(familyStore.currentBeat)
+    })(familyStore.floatingBeat)
 
     return (
       <div>

--- a/app/components/changeSlider.js
+++ b/app/components/changeSlider.js
@@ -4,51 +4,49 @@ import styled from "styled-components"
 import {observer} from "mobx-react"
 import {DEFAULT_SCORE} from "../utils"
 import chroma from "chroma-js"
-import {colors, newColors} from "../colors"
+import {newColors} from "../colors"
 
 const StyledChangeSlider = styled.span`
   display: inline-block;
   margin: 0;
   font-size: 10px;
   vertical-align: middle;
-  @media screen and (-webkit-min-device-pixel-ratio:0) {
-
-    input[type='range'] {
+  @media screen and (-webkit-min-device-pixel-ratio: 0) {
+    input[type="range"] {
       overflow: hidden;
       -webkit-appearance: none;
       background-color: ${chroma(newColors.purple.base)};
       width: 300px;
       border-radius: 4px;
     }
-    
-    input[type='range']::-webkit-slider-runnable-track {
+
+    input[type="range"]::-webkit-slider-runnable-track {
       height: 10px;
       -webkit-appearance: none;
       color: #43e5f7;
       margin-top: -1px;
     }
-    
-    input[type='range']::-webkit-slider-thumb {
+
+    input[type="range"]::-webkit-slider-thumb {
       width: 10px;
       -webkit-appearance: none;
       height: 10px;
       background: #43e5f7;
-      box-shadow: -300px 0 0 300px 
+      box-shadow: -300px 0 0 300px;
     }
-
   }
   /** FF*/
   input[type="range"]::-moz-range-progress {
-    background-color: #43e5f7; 
+    background-color: #43e5f7;
   }
-  input[type="range"]::-moz-range-track {  
+  input[type="range"]::-moz-range-track {
     background-color: ${chroma(newColors.purple.base)};
   }
   /* IE*/
   input[type="range"]::-ms-fill-lower {
-    background-color: #43e5f7; 
+    background-color: #43e5f7;
   }
-  input[type="range"]::-ms-fill-upper {  
+  input[type="range"]::-ms-fill-upper {
     background-color: ${chroma(newColors.purple.base)};
   }
 `
@@ -95,7 +93,6 @@ class ChangeSlider extends Component {
           max={MAXIMUM_CHANGE}
           step={CHANGE_STEP}
           value={this.convertScoreToChangeAmount(this.props.score)}
-
           onChange={this.handleChange}
         />
       </StyledChangeSlider>

--- a/app/components/changeSlider.js
+++ b/app/components/changeSlider.js
@@ -84,7 +84,7 @@ class ChangeSlider extends Component {
             fontSize: "15px",
           }}
         >
-          <span>Minor Change</span>
+          <span>No Change</span>
           <span>Total Change</span>
         </div>
         <input

--- a/app/components/samplerTrack.js
+++ b/app/components/samplerTrack.js
@@ -54,22 +54,19 @@ class Track extends Component {
   }
 
   handleNoteToggle = (noteNumber, wasOn, wasClicked) => {
-    const {trackNum} = this.props
+    const {beat, trackNum} = this.props
 
     if (
       wasClicked ||
-      !!wasOn ===
-        !!familyStore.currentBeat.sections.drums.tracks[trackNum].sequence[
-          noteNumber
-        ]
+      !!wasOn === !!beat.sections.drums.tracks[trackNum].sequence[noteNumber]
     ) {
-      familyStore.toggleNoteOnCurrentBeat("drums", trackNum, noteNumber)
+      familyStore.toggleNoteOnBeat(beat, "drums", trackNum, noteNumber)
     }
   }
 
   handleSampleChange = (e) => {
-    const {trackNum} = this.props
-    familyStore.setSampleOnCurrentBeat("drums", trackNum, e.target.value)
+    const {beat, trackNum} = this.props
+    familyStore.setSampleOnBeat(beat, "drums", trackNum, e.target.value)
   }
 
   renderSamplePreviewer = () => {
@@ -104,9 +101,8 @@ class Track extends Component {
             this.setState({
               lastEntered: i,
               lastClickedNoteWasOn:
-                familyStore.currentBeat.sections.drums.tracks[
-                  this.props.trackNum
-                ].sequence[i] > 0,
+                this.props.beat.sections.drums.tracks[this.props.trackNum]
+                  .sequence[i] > 0,
             })
             this.handleNoteToggle(i, note, true)
           }}
@@ -181,7 +177,8 @@ class Track extends Component {
             className="remove-track"
             title={"Delete track"}
             onClick={() => {
-              familyStore.removeTrackFromCurrentBeat(
+              familyStore.removeTrackFromBeat(
+                this.props.beat,
                 "drums",
                 this.props.trackNum,
               )

--- a/app/components/synthTrack.js
+++ b/app/components/synthTrack.js
@@ -50,22 +50,19 @@ class Track extends Component {
   }
 
   handleNoteToggle = (noteNumber, wasOn, wasClicked) => {
-    const {trackNum} = this.props
+    const {beat, trackNum} = this.props
 
     if (
       wasClicked ||
-      !!wasOn ===
-        !!familyStore.currentBeat.sections.keyboard.tracks[trackNum].sequence[
-          noteNumber
-        ]
+      !!wasOn === !!beat.sections.keyboard.tracks[trackNum].sequence[noteNumber]
     ) {
-      familyStore.toggleNoteOnCurrentBeat("keyboard", trackNum, noteNumber)
+      familyStore.toggleNoteOnBeat(beat, "keyboard", trackNum, noteNumber)
     }
   }
 
   handleSampleChange = (e) => {
-    const {trackNum} = this.props
-    familyStore.setSampleOnCurrentBeat("keyboard", trackNum, e.target.value)
+    const {beat, trackNum} = this.props
+    familyStore.setSampleOnBeat(beat, "keyboard", trackNum, e.target.value)
   }
 
   render() {
@@ -79,9 +76,8 @@ class Track extends Component {
             this.setState({
               lastEntered: i,
               lastClickedNoteWasOn:
-                familyStore.currentBeat.sections.keyboard.tracks[
-                  this.props.trackNum
-                ].sequence[i] > 0,
+                this.props.beat.sections.keyboard.tracks[this.props.trackNum]
+                  .sequence[i] > 0,
             })
             this.handleNoteToggle(i, note, true)
           }}

--- a/app/mutate.js
+++ b/app/mutate.js
@@ -1,6 +1,8 @@
 import {toJS} from "mobx"
 import {deepClone, SCALES, synthTypes} from "./utils"
 
+const MAXIMUM_SCORE = 10
+
 const randomBit = (probOn) => {
   return Math.random() < probOn ? 1 : 0
 }
@@ -26,9 +28,13 @@ const mutateSynthType = (newBeat) => {
 }
 
 const mutateMelody = (originalBeat) => {
+  if (originalBeat.synthScore === MAXIMUM_SCORE) {
+    return deepClone(toJS(originalBeat))
+  }
+
   const newBeat = deepClone(toJS(originalBeat))
 
-  newBeat.sections.keyboard.tracks[0].sequence.forEach((note, i) => {
+  newBeat.sections.keyboard.tracks[0].sequence.forEach((_note, i) => {
     let playedTrackIndex = null
 
     newBeat.sections.keyboard.tracks.forEach((track, j) => {
@@ -38,9 +44,10 @@ const mutateMelody = (originalBeat) => {
     })
 
     //flip off to on
-    const flipNote = Math.random() * 10 > originalBeat.synthScore ? true : false
+    const flipNote =
+      Math.random() * MAXIMUM_SCORE > originalBeat.synthScore ? true : false
     const switchNote =
-      Math.random() * 10 > Math.min(originalBeat.synthScore, 9.0)
+      Math.random() * MAXIMUM_SCORE > Math.min(originalBeat.synthScore, 9.0)
     const randomNoteIndex = Math.floor(Math.random() * SCALES.cmaj.length)
 
     if (flipNote && playedTrackIndex !== null) {
@@ -71,6 +78,10 @@ const mutateMelody = (originalBeat) => {
 }
 
 const mutateSampler = (originalBeat) => {
+  if (originalBeat.synthScore === MAXIMUM_SCORE) {
+    return deepClone(toJS(originalBeat))
+  }
+
   const newBeat = deepClone(toJS(originalBeat))
   newBeat.sections.drums.tracks[0].sequence.forEach((note, i) => {
     let playedTrackIndex = null
@@ -80,10 +91,11 @@ const mutateSampler = (originalBeat) => {
         playedTrackIndex = j
       }
 
-      const randomNote = Math.random() * 10 > 6.5 ? 1 : 0
+      const randomNote = Math.random() * MAXIMUM_SCORE > 6.5 ? 1 : 0
 
       track.sequence[i] =
-        Math.random() * 20 - 10 > Math.min(originalBeat.samplerScore, 9.0)
+        Math.random() * 20 - MAXIMUM_SCORE >
+        Math.min(originalBeat.samplerScore, 9.0)
           ? randomNote
           : track.sequence[i]
     })

--- a/app/stores/familyStore.js
+++ b/app/stores/familyStore.js
@@ -182,32 +182,27 @@ class FamilyStore {
     this.deleteBeatFromLineage(lastBeatIndex)
   }
 
-  @action toggleNoteOnCurrentBeat = (section, trackNum, note) => {
+  @action toggleNoteOnBeat = (beat, section, trackNum, note) => {
     const newNote =
-      this.currentBeat.sections[section].tracks[trackNum].sequence[note] === 0
-        ? 1
-        : 0
-    if (
-      section === "keyboard" &&
-      this.currentBeat.sections.keyboard.monosynth
-    ) {
-      this.currentBeat.sections[section].tracks.forEach((track, index) => {
+      beat.sections[section].tracks[trackNum].sequence[note] === 0 ? 1 : 0
+    if (section === "keyboard" && beat.sections.keyboard.monosynth) {
+      beat.sections[section].tracks.forEach((track, index) => {
         if (track.sequence[note] === 1 && trackNum !== index) {
           track.sequence[note] = 0
         }
       })
     }
-    this.currentBeat.sections[section].tracks[trackNum].sequence[note] = newNote
+    beat.sections[section].tracks[trackNum].sequence[note] = newNote
     this.updateFamilyInStorage()
   }
 
-  @action setSampleOnCurrentBeat = (section, trackNum, sample) => {
-    this.currentBeat.sections[section].tracks[trackNum].sample = sample
+  @action setSampleOnBeat = (beat, section, trackNum, sample) => {
+    beat.sections[section].tracks[trackNum].sample = sample
     this.updateFamilyInStorage()
   }
 
-  @action removeTrackFromCurrentBeat = (section, trackNum) => {
-    this.currentBeat.sections[section].tracks.splice(trackNum, 1)
+  @action removeTrackFromBeat = (beat, section, trackNum) => {
+    beat.sections[section].tracks.splice(trackNum, 1)
     this.updateFamilyInStorage()
   }
 
@@ -221,24 +216,23 @@ class FamilyStore {
     this.updateFamilyInStorage()
   }
 
-  @action setScale = (scaleName) => {
-    this.currentBeat.scale = scaleName
+  @action setScale = (beat, scaleName) => {
+    beat.scale = scaleName
     let numSynthTracks = 0
-    this.currentBeat.sections.keyboard.tracks.forEach((track, _) => {
+    beat.sections.keyboard.tracks.forEach((track, _) => {
       track.sample = SCALES[scaleName][numSynthTracks]
       numSynthTracks += 1
     })
   }
 
-  @action setSynthType = (type) => {
-    this.currentBeat.sections.keyboard.tracks.forEach((track, _) => {
+  @action setSynthType = (beat, type) => {
+    beat.sections.keyboard.tracks.forEach((track, _) => {
       track.synthType = type
     })
   }
 
-  @action toggleMonosynth = () => {
-    this.currentBeat.sections.keyboard.monosynth = !this.currentBeat.sections
-      .keyboard.monosynth
+  @action toggleMonosynth = (beat) => {
+    beat.sections.keyboard.monosynth = !beat.sections.keyboard.monosynth
   }
 }
 

--- a/app/stores/familyStore.js
+++ b/app/stores/familyStore.js
@@ -27,6 +27,7 @@ templateBeats.map((beat, i) => {
 })
 const randomBeatIndex = Math.floor(Math.random() * templateBeats.length)
 const firstBeatId = templateBeats[randomBeatIndex].id
+const firstFloatingBeat = templateBeatsMap[firstBeatId]
 
 class FamilyStore {
   //
@@ -34,6 +35,7 @@ class FamilyStore {
   //
   @observable lineage = [firstBeatId]
   @observable currentBeatId = firstBeatId
+  @observable floatingBeat = firstFloatingBeat
   @observable beats = {...templateBeatsMap}
   @observable familyName = newFamilyName
   @observable familyNames = newFamilyNames
@@ -144,6 +146,14 @@ class FamilyStore {
   @action setCurrentBeat = (beatId, lineageIndex) => {
     this.currentBeatId = beatId
     playingStore.setLineagePlayingBeatIndex(lineageIndex)
+  }
+
+  @action setFloatingBeat = (beat) => {
+    this.floatingBeat = this.newBeat(beat)
+  }
+
+  @action resetFloatingBeat = () => {
+    this.setFloatingBeat(this.currentBeat)
   }
 
   @action deleteBeatFromLineage = (index) => {

--- a/app/stores/playingStore.js
+++ b/app/stores/playingStore.js
@@ -106,8 +106,8 @@ class PlayingStore {
 
   @action toggleMuteAll = (lastState) => {
     const newState = !lastState
-    Object.keys(familyStore.currentBeat.sections).forEach((sectionName) => {
-      familyStore.currentBeat.sections[sectionName].tracks.forEach((track) => {
+    Object.keys(familyStore.floatingBeat.sections).forEach((sectionName) => {
+      familyStore.floatingBeat.sections[sectionName].tracks.forEach((track) => {
         track.mute = newState
         if (newState) {
           track.solo = lastState
@@ -117,20 +117,22 @@ class PlayingStore {
   }
 
   @action muteUnsolod = () => {
-    Object.keys(familyStore.currentBeat.sections).forEach((sectionName) => {
-      familyStore.currentBeat.sections[sectionName].tracks.forEach((track) => {
+    Object.keys(familyStore.floatingBeat.sections).forEach((sectionName) => {
+      familyStore.floatingBeat.sections[sectionName].tracks.forEach((track) => {
         if (!track.solo) {
           track.mute = true
         }
       })
     })
   }
+
   @action unsoloAllSamplerTracks = () => {
-    familyStore.currentBeat.sections.drums.tracks.forEach((track) => {
+    familyStore.floatingBeat.sections.drums.tracks.forEach((track) => {
       track.solo = false
     })
     this.numSolo = 0
   }
+
   @action handleMuteTrack = (track) => {
     if (this.numSolo === 0) {
       track.mute = !track.mute
@@ -144,7 +146,7 @@ class PlayingStore {
       track.mute = false
       this.muteUnsolod()
       if (
-        this.numSolo === familyStore.currentBeat.sections.drums.tracks.length
+        this.numSolo === familyStore.floatingBeat.sections.drums.tracks.length
       ) {
         this.unsoloAllSamplerTracks()
       }

--- a/app/templateBeats.js
+++ b/app/templateBeats.js
@@ -1,5 +1,10 @@
 /* eslint-disable filenames/match-regex */
-import {DEFAULT_SCORE} from "./utils"
+import {
+  DEFAULT_SCORE,
+  DEFAULT_MONOSYNTH,
+  DEFAULT_SOLO,
+  DEFAULT_MUTE,
+} from "./utils"
 
 export default [
   {
@@ -12,7 +17,7 @@ export default [
       keyboard: {
         name: "keyboard",
         tracks: [],
-        monosynth: true,
+        monosynth: DEFAULT_MONOSYNTH,
       },
       drums: {
         name: "drums",
@@ -20,20 +25,20 @@ export default [
           {
             sample: "samples/kick.wav",
             sequence: [1, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
           {
             sample: "samples/snare.wav",
             sequence: [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
           {
             sample: "samples/hihat.wav",
             sequence: [1, 0, 1, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
         ],
       },
@@ -48,7 +53,7 @@ export default [
     sections: {
       keyboard: {
         name: "keyboard",
-        monosynth: true,
+        monosynth: DEFAULT_MONOSYNTH,
         tracks: [
           {
             synthType: "square",
@@ -87,7 +92,7 @@ export default [
     sections: {
       keyboard: {
         name: "keyboard",
-        monosynth: true,
+        monosynth: DEFAULT_MONOSYNTH,
         tracks: [],
       },
       drums: {
@@ -96,20 +101,20 @@ export default [
           {
             sample: "samples/hi_hat.wav",
             sequence: [1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
           {
             sample: "samples/6581__ST_012.wav",
             sequence: [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
           {
             sample: "samples/snare.wav",
             sequence: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
         ],
       },
@@ -124,7 +129,7 @@ export default [
     sections: {
       keyboard: {
         name: "keyboard",
-        monosynth: true,
+        monosynth: DEFAULT_MONOSYNTH,
         tracks: [],
       },
       drums: {
@@ -133,26 +138,26 @@ export default [
           {
             sample: "samples/hi_hat.wav",
             sequence: [1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
           {
             sample: "samples/8580_PST_060.wav",
             sequence: [0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
           {
             sample: "samples/snare.wav",
             sequence: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
           {
             sample: "samples/hihat.wav",
             sequence: [1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
         ],
       },
@@ -167,7 +172,7 @@ export default [
     sections: {
       keyboard: {
         name: "keyboard",
-        monosynth: true,
+        monosynth: DEFAULT_MONOSYNTH,
         tracks: [],
       },
       drums: {
@@ -176,20 +181,20 @@ export default [
           {
             sample: "samples/Kicks/Cymatics - Trap Kick 1 - C.wav",
             sequence: [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
           {
             sample: "samples/hi_hat.wav",
             sequence: [0, 0, 1, 1, 1, 0, 0, 1, 0, 0, 1, 1, 1, 0, 1, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
           {
             sample: "samples/Snare/Cymatics - Titan Snare 3 - C.wav",
             sequence: [0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
         ],
       },
@@ -204,7 +209,7 @@ export default [
     sections: {
       keyboard: {
         name: "keyboard",
-        monosynth: true,
+        monosynth: DEFAULT_MONOSYNTH,
         tracks: [],
       },
       drums: {
@@ -213,20 +218,20 @@ export default [
           {
             sample: "samples/Percussion/Cymatics - Synth Perc 28.wav",
             sequence: [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
           {
             sample: "samples/hi_hat.wav",
             sequence: [0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
           {
             sample: "samples/Snare/Cymatics - Titan Snare 3 - C.wav",
             sequence: [0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
         ],
       },
@@ -241,7 +246,7 @@ export default [
     sections: {
       keyboard: {
         name: "keyboard",
-        monosynth: true,
+        monosynth: DEFAULT_MONOSYNTH,
         tracks: [],
       },
       drums: {
@@ -250,20 +255,20 @@ export default [
           {
             sample: "samples/kick.wav",
             sequence: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
           {
             sample: "samples/hihat.wav",
             sequence: [1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
           {
             sample: "samples/cowbell.wav",
             sequence: [0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0],
-            mute: false,
-            solo: false,
+            mute: DEFAULT_MUTE,
+            solo: DEFAULT_SOLO,
           },
         ],
       },
@@ -278,7 +283,7 @@ export default [
     sections: {
       keyboard: {
         name: "keyboard",
-        monosynth: true,
+        monosynth: DEFAULT_MONOSYNTH,
         tracks: [
           {
             sample: "c3",
@@ -317,7 +322,7 @@ export default [
     sections: {
       keyboard: {
         name: "keyboard",
-        monosynth: true,
+        monosynth: DEFAULT_MONOSYNTH,
         tracks: [
           {
             sample: "c3",
@@ -369,7 +374,7 @@ export default [
     sections: {
       keyboard: {
         name: "keyboard",
-        monosynth: true,
+        monosynth: DEFAULT_MONOSYNTH,
         tracks: [
           {
             sample: "c3",
@@ -421,7 +426,7 @@ export default [
     sections: {
       keyboard: {
         name: "keyboard",
-        monosynth: true,
+        monosynth: DEFAULT_MONOSYNTH,
         tracks: [
           {
             sample: "b3",
@@ -460,7 +465,7 @@ export default [
     sections: {
       keyboard: {
         name: "keyboard",
-        monosynth: true,
+        monosynth: DEFAULT_MONOSYNTH,
         tracks: [
           {
             sample: "b3",

--- a/app/utils.js
+++ b/app/utils.js
@@ -153,6 +153,10 @@ const generateFamilyName = () => {
 }
 
 const DEFAULT_SCORE = 10
+const DEFAULT_MUTE = false
+const DEFAULT_SOLO = false
+const DEFAULT_MONOSYNTH = true
+
 const BEAT_LENGTH = 16
 const BEAT_RESOLUTION = "16n"
 
@@ -165,6 +169,9 @@ export {
   completeScale,
   completeSamples,
   DEFAULT_SCORE,
+  DEFAULT_MUTE,
+  DEFAULT_SOLO,
+  DEFAULT_MONOSYNTH,
   BEAT_LENGTH,
   BEAT_RESOLUTION,
 }


### PR DESCRIPTION
This PR explores a different workflow for evolving beats. Instead of the discrete mutate buttons it opts to evolve the beat live as you move the change slider, giving you a preview of the beat. Then there is a save button to save that previewed beat to the lineage.

Try it out and let me know what you think!

* Continuously evolve beat as you drag the change slider
* Returning the slider back to left returns to the original beat
* Save button at the top for saving preview beat

![evolve_continously](https://user-images.githubusercontent.com/791980/62720696-88296700-b9d8-11e9-8178-56a5fa67ca76.gif)

![image](https://user-images.githubusercontent.com/791980/62720871-f110df00-b9d8-11e9-8232-cde578dc855b.png)